### PR TITLE
Floatation Update

### DIFF
--- a/Floating/Floating.csproj
+++ b/Floating/Floating.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Heinermann.Floating</RootNamespace>
     <AssemblyName>Floating</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/Floating/Helpers.cs
+++ b/Floating/Helpers.cs
@@ -80,7 +80,7 @@ namespace Heinermann.Floating
 
       if (prefab.HasAnyTags(nonFloatableTags) || !prefab.HasTag(GameTags.Pickupable)) return false;
 
-      if (prefab.HasTag(GameTags.Minion) && !prefab.HasTag(GameTags.Corpse)) return false;
+      if (prefab.HasTag(GameTags.BaseMinion) && !prefab.HasTag(GameTags.Corpse)) return false;
 
       return true;
     }

--- a/Floating/Properties/AssemblyInfo.cs
+++ b/Floating/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
+[assembly: AssemblyVersion("2.0.3.0")]
+[assembly: AssemblyFileVersion("2.0.3.0")]

--- a/Floating/mod_info.yaml
+++ b/Floating/mod_info.yaml
@@ -1,4 +1,4 @@
 supportedContent: ALL
-minimumSupportedBuild: 509629
+minimumSupportedBuild: 647408
 APIVersion: 2
-version: "2.0.2"
+version: "2.0.3"


### PR DESCRIPTION
Recent game updates are causing Floatation mod to crash.

Replaced GameTags.Minion with GameTags.BaseMinion as the former no longer exists with the addition of Bionic Duplicants. This is the source of the crash.

Target .NET Framework is now 4.8

Updated Minimum Supported Build to current game version of 647408

Incremented Mod Version Number to 2.0.3.0